### PR TITLE
Persist headers in search item description even if there is no data, #40

### DIFF
--- a/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
@@ -371,13 +371,12 @@ function addDrawControls() {
 
 function addOverlayToMap(overlay: MapLayer) {
     overlay.layerdefinitions.forEach((layerDefinition: LayerDefinition) => {
-        
-        map.value!.on('mouseenter', layerDefinition.id, () => {
-            map.value!.getCanvas().style.cursor = 'pointer';
+        map.value!.on("mouseenter", layerDefinition.id, () => {
+            map.value!.getCanvas().style.cursor = "pointer";
         });
 
-        map.value!.on('mouseleave', layerDefinition.id, () => {
-            map.value!.getCanvas().style.cursor = '';
+        map.value!.on("mouseleave", layerDefinition.id, () => {
+            map.value!.getCanvas().style.cursor = "";
         });
 
         if (!map.value!.getSource(layerDefinition.source!)) {

--- a/afrc/src/afrc/Search/components/SearchItemDetails.vue
+++ b/afrc/src/afrc/Search/components/SearchItemDetails.vue
@@ -102,13 +102,24 @@ function clearResult() {
             </div>
         </div>
         <div class="description">
-            <template
-                v-if="displaydescription && displaydescription != 'Undefined'"
-            >
-                <!-- eslint-disable-next-line vue/no-v-html -->
-                <div v-html="displaydescription"></div>
-            </template>
-            <div v-else>No description provided</div>
+            <div class="value-header">Description</div>
+            <div class="resource-details-value">
+                <template
+                    v-if="
+                        displaydescription && displaydescription != 'Undefined'
+                    "
+                >
+                    <!-- eslint-disable-next-line vue/no-v-html -->
+                    <div v-html="displaydescription"></div>
+                </template>
+                <div v-else>No description provided</div>
+            </div>
+        </div>
+        <div
+            class="value-header"
+            style="padding: 0 10px"
+        >
+            Images
         </div>
         <div
             v-if="images.length"
@@ -141,6 +152,13 @@ function clearResult() {
             </Carousel>
         </div>
         <div
+            v-else
+            class="resource-details-value"
+            style="padding: 0 13px"
+        >
+            <div>No images available</div>
+        </div>
+        <div
             class="resource-details"
             style="color: grey"
         >
@@ -166,30 +184,36 @@ function clearResult() {
                 >
             </div>
         </div>
-        <div
-            v-if="acquisitions"
-            class="resource-details"
-        >
+        <div class="resource-details">
             <div class="value-header">Acquisition Information</div>
+            <div v-if="acquisitions">
+                <div
+                    v-for="(acquisition, index) in acquisitions"
+                    :key="index"
+                >
+                    <div class="value-entry">
+                        Acquired by:<span class="resource-details-value">{{
+                            acquisition.person
+                        }}</span>
+                    </div>
+                    <div class="value-entry">
+                        Acquired on:<span class="resource-details-value">{{
+                            acquisition.date
+                        }}</span>
+                    </div>
+                    <div class="value-entry">
+                        Acquisition Details:<span
+                            class="resource-details-value"
+                            >{{ acquisition.details }}</span
+                        >
+                    </div>
+                </div>
+            </div>
             <div
-                v-for="(acquisition, index) in acquisitions"
-                :key="index"
+                v-else
+                class="resource-details-value"
             >
-                <div class="value-entry">
-                    Acquired by:<span class="resource-details-value">{{
-                        acquisition.person
-                    }}</span>
-                </div>
-                <div class="value-entry">
-                    Acquired on:<span class="resource-details-value">{{
-                        acquisition.date
-                    }}</span>
-                </div>
-                <div class="value-entry">
-                    Acquisition Details:<span class="resource-details-value">{{
-                        acquisition.details
-                    }}</span>
-                </div>
+                No acquisition information available
             </div>
         </div>
         <div class="resource-details">


### PR DESCRIPTION
Previously the result details panel headers would be missing if a resource did not have information to populate those sections.
<img width="339" alt="image" src="https://github.com/user-attachments/assets/6dd663ec-a783-4395-8ab0-f7898ccd1ddf" />


This PR persists those headers and indicates that no data is available.
<img width="337" alt="image" src="https://github.com/user-attachments/assets/a7158966-a7fa-4d3a-9143-5ff7bf67d157" />
