### PR TITLE
Prevent error when searchResult is null

### DIFF
--- a/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
@@ -371,13 +371,12 @@ function addDrawControls() {
 
 function addOverlayToMap(overlay: MapLayer) {
     overlay.layerdefinitions.forEach((layerDefinition: LayerDefinition) => {
-        
-        map.value!.on('mouseenter', layerDefinition.id, () => {
-            map.value!.getCanvas().style.cursor = 'pointer';
+        map.value!.on("mouseenter", layerDefinition.id, () => {
+            map.value!.getCanvas().style.cursor = "pointer";
         });
 
-        map.value!.on('mouseleave', layerDefinition.id, () => {
-            map.value!.getCanvas().style.cursor = '';
+        map.value!.on("mouseleave", layerDefinition.id, () => {
+            map.value!.getCanvas().style.cursor = "";
         });
 
         if (!map.value!.getSource(layerDefinition.source!)) {

--- a/afrc/src/afrc/Search/components/SearchResultItem.vue
+++ b/afrc/src/afrc/Search/components/SearchResultItem.vue
@@ -13,7 +13,7 @@ const resultSelected = inject("resultSelected") as Ref<string>;
 const image: Ref<string> = ref("");
 
 onMounted(async () => {
-    if (props.searchResult) {
+    if (props.searchResult?._source) {
         const res = await fetchImageData(
             [props.searchResult._source.resourceinstanceid],
             true,


### PR DESCRIPTION
Fixes error that occurs when the SearchResult prop is null when SearchResultItem.vue is mounted