### PR TITLE
Ensures RASColls renders properly when embedded in AFS

### DIFF
--- a/afrc/src/afrc/Search/SearchPage.vue
+++ b/afrc/src/afrc/Search/SearchPage.vue
@@ -437,9 +437,20 @@ section.afrc-search-results-panel {
     flex-grow: 1;
     padding: 15px;
     overflow-y: auto;
-    height: calc(100vh - 150px);
+    height: calc(
+        100vh - 50px
+    ); /* for display in a standalone plugin or embeded in AFS */
     min-width: 400px;
     background: #fff;
+}
+
+/* 
+The following rule is for display in as a standard plugin within RASColls.
+.base-manager-grid is an arches class, so this rule won't apply
+in a standalone plugin or when embedded in AFS.
+*/
+.base-manager-grid section.afrc-search-results-panel {
+    height: calc(100vh - 100px);
 }
 
 .search-result-list {

--- a/afrc/src/afrc/Search/SearchPage.vue
+++ b/afrc/src/afrc/Search/SearchPage.vue
@@ -288,7 +288,7 @@ onMounted(async () => {
             </section>
             <div
                 v-if="showMap && dataLoaded"
-                style="width: 100%; height: 100%"
+                style="width: 100%; height: inherit"
             >
                 <InteractiveMap
                     :basemaps="basemaps"

--- a/afrc/src/afrc/Search/SearchPage.vue
+++ b/afrc/src/afrc/Search/SearchPage.vue
@@ -439,7 +439,7 @@ section.afrc-search-results-panel {
     overflow-y: auto;
     height: calc(
         100vh - 50px
-    ); /* for display in a standalone plugin or embeded in AFS */
+    ); /* for display in a standalone plugin or embedded in AFS */
     min-width: 400px;
     background: #fff;
 }

--- a/afrc/src/afrc/Search/components/SimpleSearchFilter.vue
+++ b/afrc/src/afrc/Search/components/SimpleSearchFilter.vue
@@ -103,7 +103,9 @@ const updateQuery = function () {
                 </div>
             </template>
             <template #option="slotProps">
-                <div>{{ slotProps.option.text }}</div>
+                <div class="search-option">
+                    {{ slotProps.option.text }}
+                </div>
             </template>
         </AutoComplete>
     </div>
@@ -114,7 +116,8 @@ const updateQuery = function () {
     width: 100%;
     font-size: 1rem;
 }
-.option-group {
+.option-group,
+.search-option {
     font-size: 1.4rem;
     font-family: "Lucida Sans", "Lucida Sans Regular", "Lucida Grande",
         "Lucida Sans Unicode", Geneva, Verdana, sans-serif;

--- a/afrc/templates/views/rascoll-search.htm
+++ b/afrc/templates/views/rascoll-search.htm
@@ -27,7 +27,7 @@
         <link rel="stylesheet" href="{% webpack_static 'node_modules/font-awesome/css/font-awesome.min.css' %}" />
         <link rel="stylesheet" href="{% webpack_static 'node_modules/primeicons/primeicons.css' %}" />
         <style>
-            html {font-size: 10px}
+            html {font-size: 0.62rem;}
         </style>
     {% endblock css %}
 </head>
@@ -35,5 +35,5 @@
 
 
  {% block body %}
- <div id="rascoll-search-container" style="font-size:10px"></div>
+ <div id="rascoll-search-container" style="font-size: 1.4rem; font-weight: normal; color: #454545; -webkit-font-smoothing: antialiased!important;"></div>
  {% endblock body %}


### PR DESCRIPTION
Includes style changes that allow the RASColls search plugin to appear as it does in the RASColls app when it's embedded in AFS or rendered as a standalone plugin.