### PR TITLE
Prevent tile url from repeatedly concatenating 'cacheclear' string. #57

### DIFF
--- a/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
@@ -197,7 +197,7 @@ watch(
                 "rascolls-search",
             ) as VectorTileSource;
             const oldUrl = src.tiles[0];
-            const newUrl = `${oldUrl}?cacheclear=${Date.now()}`;
+            const newUrl = `${oldUrl.split("?cacheclear")[0]}?cacheclear=${Date.now()}`;
             src.setTiles([newUrl]);
             updateCurrentPageOfSearchResults();
         }


### PR DESCRIPTION
re #57 