### PR TITLE
Wire up basemap and overlay selector panels

### DIFF
--- a/afrc/settings.py
+++ b/afrc/settings.py
@@ -355,7 +355,7 @@ CANTALOUPE_HTTP_ENDPOINT = "http://localhost:8182/"
 
 ACCESSIBILITY_MODE = False
 
-RASCOLLS_BASEMAPS = [
+BASEMAPS = [
     {
         "name": "positron",
         "title": "Light",

--- a/afrc/settings.py
+++ b/afrc/settings.py
@@ -355,6 +355,27 @@ CANTALOUPE_HTTP_ENDPOINT = "http://localhost:8182/"
 
 ACCESSIBILITY_MODE = False
 
+RASCOLLS_BASEMAPS = [
+    {
+        "name": "positron",
+        "title": "Light",
+        "url": "https://tiles.openfreemap.org/styles/positron",
+        "attribution": "Tiles by <a href='https://www.openfreemap.org/'>Open Free Map</a>",
+        "addtomap": True,
+        "type": "xyz",
+        "iconclass": "fa fa-map",
+    },
+    {
+        "name": "liberty",
+        "title": "Streets",
+        "url": "https://tiles.openfreemap.org/styles/liberty",
+        "attribution": "Tiles by <a href='https://www.openfreemap.org/'>Open Free Map</a>",
+        "addtomap": False,
+        "type": "xyz",
+        "iconclass": "fa fa-map",
+    },
+]
+
 RENDERERS = [
     {
         "name": "imagereader",

--- a/afrc/src/afrc/Search/SearchPage.vue
+++ b/afrc/src/afrc/Search/SearchPage.vue
@@ -162,17 +162,15 @@ async function fetchSystemMapData() {
         );
 
         overlays.value.sort((a, b) => (b.sortorder ?? 0) - (a.sortorder ?? 0));
-        layers
-            .filter((layer: MapLayer) => !layer.isoverlay)
-            .forEach((layer: MapLayer) => {
-                basemaps.value.push({
-                    name: layer.name,
-                    active: layer.addtomap,
-                    value: layer.name,
-                    id: layer.name,
-                    url: "https://tiles.openfreemap.org/styles/positron",
-                });
+        mapData.rascolls_basemaps.forEach((layer: MapLayer) => {
+            basemaps.value.push({
+                name: layer.title,
+                active: layer.addtomap,
+                value: layer.name,
+                id: layer.name,
+                url: layer.url,
             });
+        });
 
         sources.value = mapData.map_sources;
     } catch (error) {

--- a/afrc/src/afrc/Search/components/InteractiveMap/InteractiveMap.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/InteractiveMap.vue
@@ -8,7 +8,7 @@ import MapComponent from "@/afrc/Search/components/InteractiveMap/components/Map
 import MapFilter from "@/afrc/Search/components/InteractiveMap/components/MapFilter/MapFilter.vue";
 import InteractionsDrawer from "@/afrc/Search/components/InteractiveMap/components/InteractionsDrawer.vue";
 // import OverlayControls from "@/afrc/Search/components/InteractiveMap/components/OverlayControls.vue";
-// import BasemapControls from "@/afrc/Search/components/InteractiveMap/components/BasemapControls.vue";
+import BasemapControls from "@/afrc/Search/components/InteractiveMap/components/BasemapControls.vue";
 
 import { fetchSettings } from "@/afrc/Search/api.ts";
 
@@ -50,14 +50,14 @@ const mapInteractionItems: MapInteractionItem[] = [
     },
     {
         name: "Basemap",
-        header: "Map Filter",
-        component: MapFilter,
+        header: "Basemap",
+        component: BasemapControls,
         icon: "pi pi-map",
     },
     {
         name: "Overlays",
-        header: "Map Filter",
-        component: MapFilter,
+        header: "Overlays",
+        component: BasemapControls,
         icon: "pi pi-globe",
     },
 ];

--- a/afrc/src/afrc/Search/components/InteractiveMap/InteractiveMap.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/InteractiveMap.vue
@@ -7,7 +7,7 @@ import { useToast } from "primevue/usetoast";
 import MapComponent from "@/afrc/Search/components/InteractiveMap/components/MapComponent.vue";
 import MapFilter from "@/afrc/Search/components/InteractiveMap/components/MapFilter/MapFilter.vue";
 import InteractionsDrawer from "@/afrc/Search/components/InteractiveMap/components/InteractionsDrawer.vue";
-// import OverlayControls from "@/afrc/Search/components/InteractiveMap/components/OverlayControls.vue";
+import OverlayControls from "@/afrc/Search/components/InteractiveMap/components/OverlayControls.vue";
 import BasemapControls from "@/afrc/Search/components/InteractiveMap/components/BasemapControls.vue";
 
 import { fetchSettings } from "@/afrc/Search/api.ts";
@@ -57,7 +57,7 @@ const mapInteractionItems: MapInteractionItem[] = [
     {
         name: "Overlays",
         header: "Overlays",
-        component: BasemapControls,
+        component: OverlayControls,
         icon: "pi pi-globe",
     },
 ];

--- a/afrc/src/afrc/Search/components/InteractiveMap/components/BasemapControls.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/components/BasemapControls.vue
@@ -40,7 +40,6 @@ onMounted(() => {
     <div
         v-for="basemap in basemaps"
         :key="basemap.id"
-        class="basemap-menu"
     >
         <div class="basemap-item">
             <RadioButton

--- a/afrc/src/afrc/Search/components/InteractiveMap/components/BasemapControls.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/components/BasemapControls.vue
@@ -40,12 +40,29 @@ onMounted(() => {
     <div
         v-for="basemap in basemaps"
         :key="basemap.id"
+        class="basemap-menu"
     >
-        <RadioButton
-            v-model="selectedBasemap"
-            :value="basemap"
-            :label="basemap.name"
-        />
-        <label>{{ basemap.name }}</label>
+        <div class="basemap-item">
+            <RadioButton
+                v-model="selectedBasemap"
+                :value="basemap"
+                :label="basemap.name"
+            />
+            <label>{{ basemap.name }}</label>
+        </div>
     </div>
 </template>
+
+<style scoped>
+.basemap-item {
+    display: flex;
+    align-items: baseline;
+    padding: 10px;
+}
+.basemap-item label {
+    padding: 7px;
+}
+.basemap-item:hover {
+    background: #f7f6fa;
+}
+</style>

--- a/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
@@ -580,6 +580,14 @@ function removeOverlayFromMap(overlay: MapLayer) {
 }
 
 function updateMapOverlays(overlays: Array<MapLayer>) {
+    // overlays.sort((a, b) => (b.sortorder ?? 0) - (a.sortorder ?? 0));
+    for (let overlay of overlays) {
+        overlay.layerdefinitions.forEach((layerDefinition: LayerDefinition) => {
+            if (map.value!.getLayer(layerDefinition.id)) {
+                map.value!.removeLayer(layerDefinition.id);
+            }
+        });
+    }
     for (let overlay of overlays) {
         if (overlay.addtomap) {
             addOverlayToMap(overlay);

--- a/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
@@ -130,7 +130,7 @@ const popupContainerRerenderKey = ref(0);
 const searchMarkers: GenericObject = {};
 
 watch(
-    () => basemap,
+    () => props.basemap,
     (basemap) => {
         if (basemap) {
             updateBasemap(basemap as Basemap);

--- a/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
@@ -580,7 +580,6 @@ function removeOverlayFromMap(overlay: MapLayer) {
 }
 
 function updateMapOverlays(overlays: Array<MapLayer>) {
-    // overlays.sort((a, b) => (b.sortorder ?? 0) - (a.sortorder ?? 0));
     for (let overlay of overlays) {
         overlay.layerdefinitions.forEach((layerDefinition: LayerDefinition) => {
             if (map.value!.getLayer(layerDefinition.id)) {

--- a/afrc/src/afrc/Search/components/InteractiveMap/components/OverlayControls.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/components/OverlayControls.vue
@@ -27,9 +27,24 @@ const overlays: Ref<Array<MapLayer>> = inject("overlays", ref([]));
         v-for="overlay in overlays"
         :key="overlay.id"
     >
-        <div style="display: flex; align-items: center">
+        <div class="overlay-item">
             <ToggleSwitch v-model="overlay.addtomap" />
             <label>{{ overlay.name }}</label>
         </div>
     </div>
 </template>
+
+<style scoped>
+.overlay-item {
+    display: flex;
+    align-items: center;
+    padding: 10px;
+}
+.overlay-item label {
+    padding: 7px;
+    margin-bottom: 0;
+}
+.overlay-item:hover {
+    background: #f7f6fa;
+}
+</style>

--- a/afrc/src/afrc/Search/types.ts
+++ b/afrc/src/afrc/Search/types.ts
@@ -37,6 +37,8 @@ export interface MapLayer {
     legend?: string | null;
     maplayerid?: string;
     name: string;
+    title: string;
+    url: string;
     searchonly?: boolean;
     sortorder?: number;
     visible: boolean;

--- a/afrc/views/map_api.py
+++ b/afrc/views/map_api.py
@@ -38,6 +38,7 @@ class MapDataAPI(View):
             {
                 "map_layers": map_layers,
                 "map_sources": map_sources,
+                "rascolls_basemaps": settings.RASCOLLS_BASEMAPS,
                 # "resource_map_layers": resource_map_layers,
                 # "resource_map_sources": resource_map_sources,
             }

--- a/afrc/views/map_api.py
+++ b/afrc/views/map_api.py
@@ -38,7 +38,7 @@ class MapDataAPI(View):
             {
                 "map_layers": map_layers,
                 "map_sources": map_sources,
-                "rascolls_basemaps": settings.RASCOLLS_BASEMAPS,
+                "rascolls_basemaps": settings.BASEMAPS,
                 # "resource_map_layers": resource_map_layers,
                 # "resource_map_sources": resource_map_sources,
             }


### PR DESCRIPTION
Implements basemap and overlay selector panels. Draws basemap from a setting rather than the database because the database schema does not have a column for a map style url. Also, using a setting allows developers to define their own basemaps layers in settings_local.py