### PR TITLE
Search result detail improvements

### DIFF
--- a/afrc/src/afrc/Search/components/SearchItemDetails.vue
+++ b/afrc/src/afrc/Search/components/SearchItemDetails.vue
@@ -253,57 +253,65 @@ function zoomToSearchResult(resourceid: string, action: string) {
         <div>
             <div class="resource-details">
                 <div class="value-header">Associated Places</div>
-                <div
-                    v-for="place in placeNames"
-                    :key="place.resourceid"
-                    style="
-                        display: flex;
-                        flex-direction: row;
-                        align-items: center;
-                        justify-content: space-between;
-                    "
-                >
-                    <div class="value-entry">
-                        <span
-                            class="resource-details-value"
-                            @click="console.log(place)"
-                            >{{ place.name }}</span
+                    <div v-if="placeNames">
+                        <div
+                            v-for="place in placeNames"
+                            :key="place.resourceid"
+                            style="
+                                display: flex;
+                                flex-direction: row;
+                                align-items: center;
+                                justify-content: space-between;
+                            "
                         >
+                            <div class="value-entry">
+                                <span
+                                    class="resource-details-value"
+                                    @click="console.log(place)"
+                                    >{{ place.name }}</span
+                                >
+                            </div>
+                            <div style="display: flex; flex-direction: row">
+                                <div v-if="hasGeom && showMap">
+                                    <Button
+                                        class="action-button"
+                                        label="Zoom to Place"
+                                        severity="secondary"
+                                        text
+                                        icon="pi pi-map-marker"
+                                        size="large"
+                                        @click="
+                                            zoomToSearchResult(place.resourceid, 'zoom')
+                                        "
+                                    />
+                                </div>
+                                <div v-if="hasGeom && showMap">
+                                    <Button
+                                        class="action-button"
+                                        label="Search Here"
+                                        severity="secondary"
+                                        text
+                                        icon="pi pi-search"
+                                        size="large"
+                                        @click="
+                                            zoomToSearchResult(
+                                                place.resourceid,
+                                                'search',
+                                            )
+                                        "
+                                    />
+                                </div>
+                            </div>
+                        </div>
                     </div>
-                    <div style="display: flex; flex-direction: row">
-                        <div v-if="hasGeom && showMap">
-                            <Button
-                                class="action-button"
-                                label="Zoom to Place"
-                                severity="secondary"
-                                text
-                                icon="pi pi-map-marker"
-                                size="large"
-                                @click="
-                                    zoomToSearchResult(place.resourceid, 'zoom')
-                                "
-                            />
-                        </div>
-                        <div v-if="hasGeom && showMap">
-                            <Button
-                                class="action-button"
-                                label="Search Here"
-                                severity="secondary"
-                                text
-                                icon="pi pi-search"
-                                size="large"
-                                @click="
-                                    zoomToSearchResult(
-                                        place.resourceid,
-                                        'search',
-                                    )
-                                "
-                            />
-                        </div>
+                    <div
+                        v-else
+                        class="resource-details-value"
+                        >
+                        No associated places available
                     </div>
                 </div>
             </div>
-        </div>
         <div v-if="hasGeom && showMap" class="zoom-to-item">
                     <Button
                         class="action-button"

--- a/afrc/src/afrc/Search/components/SearchItemDetails.vue
+++ b/afrc/src/afrc/Search/components/SearchItemDetails.vue
@@ -86,7 +86,11 @@ async function getData() {
         },
     ];
     displayname.value = resp.displayname;
-    displaydescription.value = resp.displaydescription;
+    const descriptionValue = resp.resource["Statement"]?.map(
+        (statement: GenericObject) =>
+            `${statement?.["Statement_content"]?.["@display_value"]}`,
+    );
+    displaydescription.value = descriptionValue ? descriptionValue.join("<br>") : descriptionValue;
     identifier.value = accessionNumber
         ? accessionNumber["Identifier_content"]["@display_value"]
         : "";


### PR DESCRIPTION
Uses the item's statement node to present the 'Description' in the search item details panel. Also shows 'no associated places' if a resource item has no relationship with a place instance.