### PR TITLE
Fix polygon searches that cross the antimeridian

### DIFF
--- a/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
@@ -324,14 +324,16 @@ async function fitBoundsOfFeatures(features: FeatureCollection) {
 
 async function updateFeatureSelection(selected: Ref<string[]>) {
     const source = map.value!.getSource("selected-resource") as GeoJSONSource;
-    if (selected.value.length) {
-        const geojson = await fetchResourceGeoJSON(selected.value[0]);
-        source.setData(geojson);
-    } else {
-        source.setData({
-            type: "FeatureCollection",
-            features: [],
-        });
+    if (source) {
+        if (selected.value.length) {
+            const geojson = await fetchResourceGeoJSON(selected.value[0]);
+            source.setData(geojson);
+        } else {
+            source.setData({
+                type: "FeatureCollection",
+                features: [],
+            });
+        }
     }
 }
 

--- a/afrc/utils/geo_utils.py
+++ b/afrc/utils/geo_utils.py
@@ -9,6 +9,35 @@ from arches.app.utils.geo_utils import GeoUtils as ArchesGeoUtils
 
 class GeoUtils(ArchesGeoUtils):
 
+    def split_polygon_at_antimeridian(self, geom):
+        if geom.dims == 2:
+            geom_coords = geom.coords[0]
+            max_lon = max(lon for lon, lat in geom_coords)
+            min_lon = min(lon for lon, lat in geom_coords)
+            east = GEOSGeometry('{"coordinates": [[[180.0, 86.0],[0.0,    86.0],[0.0,    -86.0],[180.0, -86.0],[180.0, 86.0]]],"type": "Polygon"}')
+            west = GEOSGeometry('{"coordinates": [[[0.0,   86.0],[-180.0, 86.0],[-180.0, -86.0],[0.0,   -86.0],[0.0, 86.0]]],"type": "Polygon"}')
+            new_coords = []
+
+            # geom extends from eastern to western hemisphere
+            if max_lon > 180:
+                for coords in geom_coords:
+                    lon, lat = coords
+                    lon = lon - 360 if lon > 180 else -179.99
+                    new_coords.append([lon, lat])
+                updated_geom = GEOSGeometry(json.dumps({"coordinates": [new_coords,], "type":"Polygon"}))
+                return (geom.intersection(east), updated_geom.intersection(west))
+
+            # geom extends from western to eastern hemisphere
+            if min_lon < -180:
+                for coords in geom_coords:
+                    lon, lat = coords
+                    lon = lon + 360 if lon < 180 else 179.99
+                    new_coords.append([lon, lat])
+                updated_geom = GEOSGeometry(json.dumps({"coordinates": [new_coords,], "type":"Polygon"}))
+                return (updated_geom.intersection(east), geom.intersection(west))
+        
+        return [geom]
+
     def buffer_feature_collection(self, feature_collection):
         """
         Takes a FeatureCollection object and a value for the buffer distance in meters,

--- a/afrc/utils/geo_utils.py
+++ b/afrc/utils/geo_utils.py
@@ -10,6 +10,14 @@ from arches.app.utils.geo_utils import GeoUtils as ArchesGeoUtils
 class GeoUtils(ArchesGeoUtils):
 
     def split_polygon_at_antimeridian(self, geom):
+        """
+        If a polygon is drawn starting in the west and extends into the east, its eastern coordinates
+        will be less that -180. If a polygon starts in the east and extends west, its western coordinates
+        will exceed 180. 
+        To correct for this, adjust the coordinates in the extended area, and split the polygon into two 
+        using an intersection with polygon for the corresponding hemisphere.
+        """
+
         if geom.dims == 2:
             geom_coords = geom.coords[0]
             extends_into_western_hemisphere = max(lon for lon, lat in geom_coords) > 180

--- a/afrc/utils/geo_utils.py
+++ b/afrc/utils/geo_utils.py
@@ -2,9 +2,7 @@ import json
 import uuid
 from django.contrib.gis.geos import (
     GEOSGeometry,
-    GeometryCollection,
 )
-from django.db import connection
 from arches.app.models.system_settings import settings
 from arches.app.utils.geo_utils import GeoUtils as ArchesGeoUtils
 

--- a/afrc/views/search_api.py
+++ b/afrc/views/search_api.py
@@ -42,7 +42,6 @@ searchresults_cache = caches["searchresults"]
 
 
 class SearchAPI(View):
-
     def get(self, request):
         current_page = int(request.GET.get("paging-filter", 1))
         page_size = int(settings.SEARCH_ITEMS_PER_PAGE)


### PR DESCRIPTION
This change allows a user to perfom a spatial filter with a polygon that crosses the antimeridian. Unfortunately this does not apply to buffered geometries because GEOS does not properly buffer polygons if they straddle the meridian before or after the buffer operation. 